### PR TITLE
Release engineering: CI, tag-driven releases, v2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Tests
+        run: cargo test
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: End-to-end smoke (raw K8s traceability)
+        run: |
+          ./target/release/reticulum -p tests/monorepo-08 --scan-only \
+            -o /tmp/scan-08.json --graph /tmp/graph-08.mmd
+          python3 - <<'EOF'
+          import json
+          d = json.load(open("/tmp/scan-08.json"))
+          svc = {s["id"]: s for s in d["services"]}
+          rp = svc["web-frontend"]["riskProfile"]
+          assert rp["isPublic"], "web-frontend must be public via Ingress chain"
+          assert rp["exposurePaths"] == [
+              "Ingress/web-ingress → Service/web-svc → Deployment/web-frontend"
+          ], rp["exposurePaths"]
+          assert svc["internal-batch"]["riskProfile"]["isPrivileged"]
+          assert svc["postgres-db"]["riskProfile"]["isPublic"]
+          print("monorepo-08 traceability OK")
+          EOF
+
+      - name: End-to-end smoke (SARIF scoring)
+        run: |
+          ./target/release/reticulum -p tests/monorepo-06 \
+            -s tests/fixtures/synthetic-trivy.sarif -o /tmp/full-06.json
+          python3 - <<'EOF'
+          import json
+          d = json.load(open("/tmp/full-06.json"))
+          scores = {s["id"]: s["maxReticulumScore"] for s in d["services"]}
+          expected = {"admin-api": 100, "internal-worker": 49, "payment-go": 22, "postgres-db": 35}
+          assert scores == expected, scores
+          print("monorepo-06 scoring OK", scores)
+          EOF
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -t reticulum:ci .
+      - name: Smoke run
+        run: docker run --rm -v "$PWD:/data" reticulum:ci -p /data/tests/monorepo-06 --scan-only --rules /app/rules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: linux-amd64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+            artifact: linux-arm64
+          - target: x86_64-apple-darwin
+            os: macos-13
+            artifact: darwin-amd64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: darwin-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          PKG="reticulum-${VERSION}-${{ matrix.artifact }}"
+          mkdir -p "dist/${PKG}"
+          cp "target/${{ matrix.target }}/release/reticulum" "dist/${PKG}/"
+          cp -r rules "dist/${PKG}/rules"
+          cp README.md LICENSE RULES.md "dist/${PKG}/"
+          tar -czf "${PKG}.tar.gz" -C dist "${PKG}"
+          shasum -a 256 "${PKG}.tar.gz" > "${PKG}.tar.gz.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: reticulum-${{ matrix.artifact }}
+          path: |
+            *.tar.gz
+            *.tar.gz.sha256
+
+  docker:
+    name: Multi-arch image → GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest
+
+  release:
+    name: GitHub Release
+    needs: [binaries, docker]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            *.tar.gz
+            *.tar.gz.sha256
+          generate_release_notes: true
+          body: |
+            ## Install
+
+            **Docker (multi-arch):**
+            ```bash
+            docker pull ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ```
+
+            **Binary:** download the tarball for your platform below — it bundles
+            the default rule set, README, RULES.md and LICENSE. Verify with the
+            accompanying `.sha256` file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to Reticulum are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
+[Semantic Versioning](https://semver.org/).
+
+## [2.0.0] — 2026-07-02
+
+Complete rewrite in Rust plus a major capability expansion. Reports are a
+superset of v1 (new fields are additive) with two intentional changes noted
+below.
+
+### Added
+- **Multi-source resource mapping**: raw Kubernetes manifests (Deployments,
+  StatefulSets, DaemonSets, ReplicaSets, Jobs, CronJobs, Pods) and
+  docker-compose stacks, alongside the existing Helm chart discovery. Each
+  service in the report carries a `source` field (`helm` | `k8s` | `compose`).
+- **Exposure traceability**: label-selector and backend-ref resolution across
+  manifests produces explicit chains (`Ingress/x → Service/y → Deployment/z`,
+  LoadBalancer/NodePort services, NetworkPolicy open egress), reported in the
+  CLI, in `riskProfile.exposurePaths` and in the new exposure graph.
+- **`--graph <file>`**: Mermaid flowchart of the exposure surface with
+  priority-colored nodes and per-chain edges.
+- **Rule DSL v2** (backward compatible): `\.` escaped dots, `*` wildcards and
+  numeric indices in key paths; `any:` OR blocks; `in`, `gte`, `lte`,
+  `not_exists` operators; finding matching on `severity` and `location`;
+  `set_flags` with explicit booleans (flags can now be cleared); `manifest`
+  target with `kind:` filter — including compose services as
+  `kind: ComposeService`; validation warnings for malformed rules.
+- **`--rules <dir>`**: explicit rule-set location, with CWD and
+  executable-directory fallbacks.
+- Default manifest rules (`rules/manifest/`): privileged containers,
+  hostNetwork, dangerous capabilities, hostPath mounts.
+- Documentation set: rewritten `RULES.md` (full reference + cookbook),
+  `docs/architecture.md`, `docs/scoring.md`, `docs/sources.md`,
+  `docs/integrations.md`.
+- CI (tests, clippy, rustfmt, e2e smoke, Docker build) and tag-driven release
+  automation (multi-platform binaries + multi-arch GHCR image).
+- Test fixtures `tests/monorepo-08` (raw K8s traceability) and
+  `tests/monorepo-09` (docker-compose).
+
+### Fixed
+Thirteen defects inherited from the D implementation, documented in
+[AUDIT.md](AUDIT.md). Highlights:
+- NaN score corruption when rules omitted `score_multiplier`/`score_factor`.
+- Per-finding fixability mutating the shared chart profile (SARIF
+  order-dependent scores).
+- Crash on SARIF results without `ruleId`; integer `security-severity`
+  ignored; out-of-range severities now clamped.
+- Rules silently not loading when the binary ran outside the repo root.
+- String-prefix path matching mislinking sibling directories
+  (`apps/api` vs `apps/api-gateway`) in both finding attribution and
+  chart linking.
+- The shipped IAM rules (IRSA / GCP Workload Identity) never matched — the
+  v1 engine could not address annotation keys containing dots.
+
+### Changed
+- **Intentional output changes:** service `type` is now `HelmLinked`
+  (was the `HelmVinked` typo); `riskProfile.baseRiskScore` no longer depends
+  on SARIF result order. Rule load order is deterministic (sorted), so
+  `appliedRuleIds` ordering is stable across machines.
+- Build toolchain: `cargo build --release` replaces `dub build`;
+  the Docker image builds from `rust:1-slim-bookworm`.
+
+## [1.0.0] — 2025
+
+Initial public release (D implementation): Helm chart discovery, values-based
+exposure rules, SARIF ingestion with contextual scoring, enriched SARIF and
+JSON reports.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reticulum"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "clap",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reticulum"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 description = "Context-aware security prioritization engine"
 license = "MIT"

--- a/build_release.sh
+++ b/build_release.sh
@@ -1,27 +1,39 @@
 #!/bin/bash
 set -e
 
-VERSION="v1.0.0"
-DIST_DIR="dist"
-ARCHIVE_NAME="reticulum-${VERSION}-linux-amd64.tar.gz"
+# Local release build. CI releases (multi-platform) are produced by
+# .github/workflows/release.yml on tag push; this script packages a tarball
+# for the HOST platform only.
 
-echo "[*] Building Reticulum Release ${VERSION}..."
+VERSION="v$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)"
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  x86_64) ARCH="amd64" ;;
+  arm64|aarch64) ARCH="arm64" ;;
+esac
+
+DIST_DIR="dist"
+PKG="reticulum-${VERSION}-${OS}-${ARCH}"
+ARCHIVE_NAME="${PKG}.tar.gz"
+
+echo "[*] Building Reticulum Release ${VERSION} (${OS}/${ARCH})..."
 
 # Build binary
 cargo build --release
 
 # Prepare distribution directory
-rm -rf ${DIST_DIR}
-mkdir -p ${DIST_DIR}/rules
+rm -rf "${DIST_DIR}"
+mkdir -p "${DIST_DIR}/${PKG}/rules"
 
 # Copy assets
-cp target/release/reticulum ${DIST_DIR}/
-cp -r rules/* ${DIST_DIR}/rules/
-cp README.md ${DIST_DIR}/
-cp LICENSE ${DIST_DIR}/
+cp target/release/reticulum "${DIST_DIR}/${PKG}/"
+cp -r rules/* "${DIST_DIR}/${PKG}/rules/"
+cp README.md RULES.md LICENSE "${DIST_DIR}/${PKG}/"
 
 # Create archive
 echo "[*] Creating archive ${ARCHIVE_NAME}..."
-tar -czf ${ARCHIVE_NAME} -C ${DIST_DIR} .
+tar -czf "${ARCHIVE_NAME}" -C "${DIST_DIR}" "${PKG}"
+shasum -a 256 "${ARCHIVE_NAME}" > "${ARCHIVE_NAME}.sha256"
 
 echo "[+] Release ready: ${ARCHIVE_NAME}"

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -7,7 +7,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 pub fn analyze_exposure(chart: &mut Chart, engine: &RuleEngine) {
-    println!("  [Analyzer] Analyzing chart: {} → {}", chart.name, chart.path);
+    println!(
+        "  [Analyzer] Analyzing chart: {} → {}",
+        chart.name, chart.path
+    );
     chart.risk.reset();
 
     // 1. Evaluate Metadata Rules
@@ -31,11 +34,19 @@ pub fn analyze_exposure(chart: &mut Chart, engine: &RuleEngine) {
     );
     println!(
         "      • Privileged         : {}",
-        if chart.risk.is_privileged { "YES" } else { "NO" }
+        if chart.risk.is_privileged {
+            "YES"
+        } else {
+            "NO"
+        }
     );
     println!(
         "      • Dangerous Caps     : {}",
-        if chart.risk.has_dangerous_caps { "YES" } else { "NO" }
+        if chart.risk.has_dangerous_caps {
+            "YES"
+        } else {
+            "NO"
+        }
     );
     println!(
         "      • Svc Token Mount    : {}",

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -59,8 +59,16 @@ pub fn render_mermaid(services: &[Service], charts: &[Chart]) -> String {
                     .cloned()
                     .collect::<Vec<_>>()
                     .join(", ");
-                let label = if rules.is_empty() { "exposed".to_string() } else { rules };
-                edges.push(format!("    internet -->|\"{}\"| {}\n", escape(&label), node));
+                let label = if rules.is_empty() {
+                    "exposed".to_string()
+                } else {
+                    rules
+                };
+                edges.push(format!(
+                    "    internet -->|\"{}\"| {}\n",
+                    escape(&label),
+                    node
+                ));
             }
             continue;
         }
@@ -68,7 +76,11 @@ pub fn render_mermaid(services: &[Service], charts: &[Chart]) -> String {
         for path in &c.risk.exposure_paths {
             if let Some((label, _)) = path.split_once(" ← ") {
                 // Outbound: open egress from the workload to the internet
-                edges.push(format!("    {} -.->|\"{}\"| internet\n", node, escape(label)));
+                edges.push(format!(
+                    "    {} -.->|\"{}\"| internet\n",
+                    node,
+                    escape(label)
+                ));
                 continue;
             }
 
@@ -221,7 +233,11 @@ mod tests {
     #[test]
     fn graph_internal_service_has_no_internet_edge() {
         let chart = Chart::new("worker", "/repo/charts/worker");
-        let mut svc = Service::new("worker", "/repo/apps/worker/Dockerfile", "/repo/apps/worker");
+        let mut svc = Service::new(
+            "worker",
+            "/repo/apps/worker/Dockerfile",
+            "/repo/apps/worker",
+        );
         svc.chart = Some(0);
         let out = render_mermaid(&[svc], &[chart]);
         assert!(out.contains("svc_worker"));
@@ -233,8 +249,15 @@ mod tests {
     fn graph_helm_public_uses_rule_labels() {
         let mut chart = Chart::new("admin-api", "/repo/charts/admin-api");
         chart.risk.set_flag("isPublic", true);
-        chart.risk.applied_rule_ids.push("exposure-ingress-enabled".to_string());
-        let mut svc = Service::new("admin-api", "/repo/apps/admin/Dockerfile", "/repo/apps/admin");
+        chart
+            .risk
+            .applied_rule_ids
+            .push("exposure-ingress-enabled".to_string());
+        let mut svc = Service::new(
+            "admin-api",
+            "/repo/apps/admin/Dockerfile",
+            "/repo/apps/admin",
+        );
         svc.chart = Some(0);
         let out = render_mermaid(&[svc], &[chart]);
         assert!(out.contains("internet -->|\"exposure-ingress-enabled\"| svc_admin_api"));

--- a/src/ingestor.rs
+++ b/src/ingestor.rs
@@ -299,8 +299,7 @@ pub fn process_sarif(
                 let svc_dir = normalize(Path::new(&service.directory));
                 let svc_docker = normalize(Path::new(&service.dockerfile_path));
 
-                let is_inside =
-                    finding_path == svc_docker || finding_path.starts_with(&svc_dir);
+                let is_inside = finding_path == svc_docker || finding_path.starts_with(&svc_dir);
                 if !is_inside {
                     continue;
                 }
@@ -465,12 +464,24 @@ mod tests {
 
     #[test]
     fn fixable_detection() {
-        assert!(is_fixable(&json!({"properties": {"trivy:fixedVersion": "1.2.3"}})));
-        assert!(!is_fixable(&json!({"properties": {"trivy:fixedVersion": ""}})));
-        assert!(!is_fixable(&json!({"properties": {"trivy:fixedVersion": "null"}})));
-        assert!(is_fixable(&json!({"properties": {"github:fixAvailable": true}})));
-        assert!(is_fixable(&json!({"properties": {"github:fixAvailable": "true"}})));
-        assert!(!is_fixable(&json!({"properties": {"github:fixAvailable": false}})));
+        assert!(is_fixable(
+            &json!({"properties": {"trivy:fixedVersion": "1.2.3"}})
+        ));
+        assert!(!is_fixable(
+            &json!({"properties": {"trivy:fixedVersion": ""}})
+        ));
+        assert!(!is_fixable(
+            &json!({"properties": {"trivy:fixedVersion": "null"}})
+        ));
+        assert!(is_fixable(
+            &json!({"properties": {"github:fixAvailable": true}})
+        ));
+        assert!(is_fixable(
+            &json!({"properties": {"github:fixAvailable": "true"}})
+        ));
+        assert!(!is_fixable(
+            &json!({"properties": {"github:fixAvailable": false}})
+        ));
         assert!(is_fixable(&json!({"fix": {"description": "x"}})));
         assert!(is_fixable(&json!({}))); // SAST default
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,10 @@ fn main() -> ExitCode {
     let abs_repo_path = match fs::canonicalize(&repo_path) {
         Ok(p) => p,
         Err(e) => {
-            ui::print_error(&format!("Cannot resolve repository path '{}': {}", repo_path, e));
+            ui::print_error(&format!(
+                "Cannot resolve repository path '{}': {}",
+                repo_path, e
+            ));
             return ExitCode::FAILURE;
         }
     };
@@ -174,9 +177,7 @@ fn main() -> ExitCode {
     let mut engine = RuleEngine::new();
     match find_rules_base(args.rules.as_deref()) {
         Some(base) => load_rule_sets(&mut engine, &base),
-        None => ui::print_warning(
-            "No rules directory found (use --rules); running without rules.",
-        ),
+        None => ui::print_warning("No rules directory found (use --rules); running without rules."),
     }
 
     ui::print_phase(

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -150,7 +150,11 @@ mod tests {
 
     #[test]
     fn match_score_name_and_path() {
-        let s = Service::new("payment-go", "/repo/apps/payment-go/Dockerfile", "/repo/apps/payment-go");
+        let s = Service::new(
+            "payment-go",
+            "/repo/apps/payment-go/Dockerfile",
+            "/repo/apps/payment-go",
+        );
         let c = Chart::new("payment-go", "/repo/charts/payment-go");
         // Name matches (+100); paths don't nest; no values.yaml on disk
         assert_eq!(calculate_match_score(&s, &c), 100);

--- a/src/model.rs
+++ b/src/model.rs
@@ -260,7 +260,12 @@ impl Service {
         }
 
         // Findings Summary
-        let max_base = self.findings.iter().map(|f| f.base_score).max().unwrap_or(0);
+        let max_base = self
+            .findings
+            .iter()
+            .map(|f| f.base_score)
+            .max()
+            .unwrap_or(0);
         let max_ret = self
             .findings
             .iter()

--- a/src/rules/engine.rs
+++ b/src/rules/engine.rs
@@ -326,7 +326,11 @@ mod tests {
     }
 
     fn m(key: &str, op: MatchOp, value: MatchValue) -> RuleMatch {
-        RuleMatch { key: key.into(), op, value }
+        RuleMatch {
+            key: key.into(),
+            op,
+            value,
+        }
     }
 
     const INGRESS_RULE: &str = r#"
@@ -354,7 +358,10 @@ action:
         engine.evaluate_values(&mut chart, &values);
         assert!(chart.risk.is_public);
         assert_eq!(chart.risk.multipliers, vec![1.3]);
-        assert_eq!(chart.risk.applied_rule_ids, vec!["exposure-ingress-enabled"]);
+        assert_eq!(
+            chart.risk.applied_rule_ids,
+            vec!["exposure-ingress-enabled"]
+        );
         assert_eq!(chart.tags, vec!["public-facing"]);
     }
 
@@ -389,7 +396,10 @@ action:
         );
         // Nested variant matches
         let mut chart = Chart::new("a", "/tmp/a");
-        engine.evaluate_values(&mut chart, &yaml("istio:\n  virtualservice:\n    enabled: true\n"));
+        engine.evaluate_values(
+            &mut chart,
+            &yaml("istio:\n  virtualservice:\n    enabled: true\n"),
+        );
         assert!(chart.risk.is_public);
         // Root variant matches
         let mut chart = Chart::new("b", "/tmp/b");
@@ -504,30 +514,69 @@ action:
 
         assert!(check_values_match(
             &values,
-            &m("service.type", MatchOp::In, MatchValue::List(vec!["LoadBalancer".into(), "NodePort".into()]))
+            &m(
+                "service.type",
+                MatchOp::In,
+                MatchValue::List(vec!["LoadBalancer".into(), "NodePort".into()])
+            )
         ));
         assert!(!check_values_match(
             &values,
-            &m("service.type", MatchOp::In, MatchValue::List(vec!["ClusterIP".into()]))
+            &m(
+                "service.type",
+                MatchOp::In,
+                MatchValue::List(vec!["ClusterIP".into()])
+            )
         ));
-        assert!(check_values_match(&values, &m("replicas", MatchOp::Gte, MatchValue::Int(3))));
-        assert!(!check_values_match(&values, &m("replicas", MatchOp::Gte, MatchValue::Int(4))));
-        assert!(check_values_match(&values, &m("replicas", MatchOp::Lte, MatchValue::Int(3))));
-        assert!(check_values_match(&values, &m("weight", MatchOp::Gt, MatchValue::Float(2.0))));
-        assert!(check_values_match(&values, &m("missing.key", MatchOp::NotExists, MatchValue::None)));
-        assert!(!check_values_match(&values, &m("replicas", MatchOp::NotExists, MatchValue::None)));
+        assert!(check_values_match(
+            &values,
+            &m("replicas", MatchOp::Gte, MatchValue::Int(3))
+        ));
+        assert!(!check_values_match(
+            &values,
+            &m("replicas", MatchOp::Gte, MatchValue::Int(4))
+        ));
+        assert!(check_values_match(
+            &values,
+            &m("replicas", MatchOp::Lte, MatchValue::Int(3))
+        ));
+        assert!(check_values_match(
+            &values,
+            &m("weight", MatchOp::Gt, MatchValue::Float(2.0))
+        ));
+        assert!(check_values_match(
+            &values,
+            &m("missing.key", MatchOp::NotExists, MatchValue::None)
+        ));
+        assert!(!check_values_match(
+            &values,
+            &m("replicas", MatchOp::NotExists, MatchValue::None)
+        ));
     }
 
     #[test]
     fn match_ops_on_values() {
         let values = yaml("replicas: 3\nservice:\n  type: ClusterIP\nname: auth-api\n");
 
-        assert!(check_values_match(&values, &m("replicas", MatchOp::Eq, MatchValue::Int(3))));
-        assert!(check_values_match(&values, &m("replicas", MatchOp::Gt, MatchValue::Int(2))));
-        assert!(!check_values_match(&values, &m("replicas", MatchOp::Lt, MatchValue::Int(2))));
         assert!(check_values_match(
             &values,
-            &m("service.type", MatchOp::Neq, MatchValue::Str("LoadBalancer".into()))
+            &m("replicas", MatchOp::Eq, MatchValue::Int(3))
+        ));
+        assert!(check_values_match(
+            &values,
+            &m("replicas", MatchOp::Gt, MatchValue::Int(2))
+        ));
+        assert!(!check_values_match(
+            &values,
+            &m("replicas", MatchOp::Lt, MatchValue::Int(2))
+        ));
+        assert!(check_values_match(
+            &values,
+            &m(
+                "service.type",
+                MatchOp::Neq,
+                MatchValue::Str("LoadBalancer".into())
+            )
         ));
         assert!(check_values_match(
             &values,
@@ -548,11 +597,19 @@ action:
         let values = yaml("features:\n  - metrics\n  - tracing\n");
         assert!(check_values_match(
             &values,
-            &m("features", MatchOp::Contains, MatchValue::Str("tracing".into()))
+            &m(
+                "features",
+                MatchOp::Contains,
+                MatchValue::Str("tracing".into())
+            )
         ));
         assert!(!check_values_match(
             &values,
-            &m("features", MatchOp::Contains, MatchValue::Str("debug".into()))
+            &m(
+                "features",
+                MatchOp::Contains,
+                MatchValue::Str("debug".into())
+            )
         ));
     }
 
@@ -579,10 +636,7 @@ action:
         );
         let mut chart = Chart::new("w", "/tmp/w");
         // Wrong kind: no fire even though path exists
-        engine.evaluate_manifest(
-            &mut chart,
-            &yaml("kind: ConfigMap\nspec:\n  rules: []\n"),
-        );
+        engine.evaluate_manifest(&mut chart, &yaml("kind: ConfigMap\nspec:\n  rules: []\n"));
         assert!(!chart.risk.is_public);
         // Right kind
         engine.evaluate_manifest(
@@ -610,8 +664,7 @@ action:
 "#,
         );
         let mut chart = Chart::new("w", "/tmp/w");
-        let deployment =
-            yaml("kind: Deployment\nmetadata:\n  labels:\n    team: payments\n");
+        let deployment = yaml("kind: Deployment\nmetadata:\n  labels:\n    team: payments\n");
         let service = yaml("kind: Service\nmetadata:\n  labels:\n    team: payments\n");
         let ingress = yaml("kind: Ingress\nmetadata:\n  labels:\n    team: payments\n");
         engine.evaluate_manifest(&mut chart, &deployment);

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -69,10 +69,10 @@ pub struct RuleMatch {
 /// score — the D original's NaN defaults did exactly that.
 #[derive(Debug, Clone, Default)]
 pub struct RiskProfileMod {
-    pub set_flag: Option<String>,          // Legacy: flag to set to true
-    pub set_flags: Vec<(String, bool)>,    // v2: explicit flag -> value pairs
-    pub score_multiplier: Option<f32>,     // Multiplier to apply
-    pub score_boost: Option<i32>,          // Raw points to add
+    pub set_flag: Option<String>,       // Legacy: flag to set to true
+    pub set_flags: Vec<(String, bool)>, // v2: explicit flag -> value pairs
+    pub score_multiplier: Option<f32>,  // Multiplier to apply
+    pub score_boost: Option<i32>,       // Raw points to add
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/rules/parser.rs
+++ b/src/rules/parser.rs
@@ -134,9 +134,9 @@ fn parse_match_list(
                 Yaml::Number(n) if n.is_i64() => MatchValue::Int(n.as_i64().unwrap_or(0)),
                 Yaml::Number(n) => MatchValue::Float(n.as_f64().unwrap_or(0.0)),
                 Yaml::String(s) => MatchValue::Str(s.clone()),
-                Yaml::Sequence(seq) => MatchValue::List(
-                    seq.iter().map(yaml_scalar_to_string).collect(),
-                ),
+                Yaml::Sequence(seq) => {
+                    MatchValue::List(seq.iter().map(yaml_scalar_to_string).collect())
+                }
                 _ => MatchValue::None,
             };
         }
@@ -206,7 +206,9 @@ fn parse_action(act: &Yaml, rule: &mut Rule, source: &str, warnings: &mut Vec<St
 }
 
 pub(crate) fn yaml_str(node: &Yaml, key: &str) -> Option<String> {
-    node.get(key).map(yaml_scalar_to_string).filter(|s| !s.is_empty())
+    node.get(key)
+        .map(yaml_scalar_to_string)
+        .filter(|s| !s.is_empty())
 }
 
 /// Numeric fields may arrive as float, int or quoted string.
@@ -257,7 +259,10 @@ action:
         assert!(warnings.is_empty(), "unexpected: {:?}", warnings);
         assert_eq!(rule.id, "exposure-ingress-enabled");
         assert_eq!(rule.matches.len(), 1);
-        assert_eq!(rule.action.risk_profile.set_flag.as_deref(), Some("isPublic"));
+        assert_eq!(
+            rule.action.risk_profile.set_flag.as_deref(),
+            Some("isPublic")
+        );
         assert_eq!(rule.action.risk_profile.score_multiplier, Some(1.3));
     }
 
@@ -285,7 +290,10 @@ action:
         assert_eq!(rule.any_matches.len(), 2);
         assert_eq!(
             rule.action.risk_profile.set_flags,
-            vec![("isPublic".to_string(), true), ("mountServiceToken".to_string(), false)]
+            vec![
+                ("isPublic".to_string(), true),
+                ("mountServiceToken".to_string(), false)
+            ]
         );
     }
 

--- a/src/rules/path.rs
+++ b/src/rules/path.rs
@@ -81,7 +81,11 @@ mod tests {
     fn escaped_dots_stay_in_segment() {
         assert_eq!(
             parse_key("serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"),
-            vec!["serviceAccount", "annotations", "eks.amazonaws.com/role-arn"]
+            vec![
+                "serviceAccount",
+                "annotations",
+                "eks.amazonaws.com/role-arn"
+            ]
         );
     }
 

--- a/src/sources/compose.rs
+++ b/src/sources/compose.rs
@@ -119,7 +119,10 @@ pub fn discover(
     }
 
     if !inv.units.is_empty() {
-        println!("  [Compose] Discovered {} compose services", inv.units.len());
+        println!(
+            "  [Compose] Discovered {} compose services",
+            inv.units.len()
+        );
     }
     inv
 }
@@ -157,7 +160,10 @@ fn build_context(definition: &Yaml, compose_dir: &Path) -> (Option<PathBuf>, Opt
 pub fn analyze(inv: &ComposeInventory, charts: &mut [Chart], engine: &RuleEngine) {
     for unit in &inv.units {
         let chart = &mut charts[unit.chart_idx];
-        println!("  [Analyzer] Analyzing compose service: {} ({})", unit.name, unit.file);
+        println!(
+            "  [Analyzer] Analyzing compose service: {} ({})",
+            unit.name, unit.file
+        );
         chart.risk.reset();
         engine.evaluate_metadata(chart);
 
@@ -175,7 +181,11 @@ pub fn analyze(inv: &ComposeInventory, charts: &mut [Chart], engine: &RuleEngine
         );
         println!(
             "      • Privileged         : {}",
-            if chart.risk.is_privileged { "YES" } else { "NO" }
+            if chart.risk.is_privileged {
+                "YES"
+            } else {
+                "NO"
+            }
         );
         for path in &chart.risk.exposure_paths {
             println!("      ⇢ EXPOSURE PATH: {}", path);
@@ -198,7 +208,10 @@ fn analyze_ports(chart: &mut Chart, unit: &ComposeUnit) {
     }
     chart.risk.set_flag("isPublic", true);
     chart.risk.add_multiplier(1.3);
-    chart.risk.applied_rule_ids.push("compose-exposure-ports".to_string());
+    chart
+        .risk
+        .applied_rule_ids
+        .push("compose-exposure-ports".to_string());
     for desc in published {
         chart
             .risk
@@ -259,14 +272,20 @@ fn analyze_security(chart: &mut Chart, unit: &ComposeUnit) {
     if def.get("privileged").and_then(|p| p.as_bool()) == Some(true) {
         chart.risk.set_flag("isPrivileged", true);
         chart.risk.add_boost(20);
-        chart.risk.applied_rule_ids.push("compose-privileged".to_string());
+        chart
+            .risk
+            .applied_rule_ids
+            .push("compose-privileged".to_string());
         println!("      → RULE MATCH: Compose privileged container (compose-privileged)");
     }
 
     if def.get("network_mode").and_then(|n| n.as_str()) == Some("host") {
         chart.risk.set_flag("isPrivileged", true);
         chart.risk.add_multiplier(1.5);
-        chart.risk.applied_rule_ids.push("compose-host-network".to_string());
+        chart
+            .risk
+            .applied_rule_ids
+            .push("compose-host-network".to_string());
         println!("      → RULE MATCH: Compose host network (compose-host-network)");
     }
 
@@ -279,7 +298,10 @@ fn analyze_security(chart: &mut Chart, unit: &ComposeUnit) {
         if !dangerous.is_empty() {
             chart.risk.set_flag("hasDangerousCaps", true);
             chart.risk.add_boost(15);
-            chart.risk.applied_rule_ids.push("compose-dangerous-caps".to_string());
+            chart
+                .risk
+                .applied_rule_ids
+                .push("compose-dangerous-caps".to_string());
             println!(
                 "      → RULE MATCH: Compose dangerous capabilities {:?} (compose-dangerous-caps)",
                 dangerous
@@ -345,7 +367,10 @@ mod tests {
             file: "docker-compose.yml".into(),
         };
         let doc = synthetic_doc(&unit);
-        assert_eq!(doc.get("kind").and_then(|k| k.as_str()), Some("ComposeService"));
+        assert_eq!(
+            doc.get("kind").and_then(|k| k.as_str()),
+            Some("ComposeService")
+        );
         assert_eq!(doc.get("image").and_then(|i| i.as_str()), Some("nginx"));
     }
 }

--- a/src/sources/k8s.rs
+++ b/src/sources/k8s.rs
@@ -52,11 +52,7 @@ pub struct K8sInventory {
 
 /// Scan for raw manifests, appending one config unit per workload and a
 /// Service entry (for finding attribution) when none exists for that id.
-pub fn discover(
-    root: &Path,
-    charts: &mut Vec<Chart>,
-    services: &mut Vec<Service>,
-) -> K8sInventory {
+pub fn discover(root: &Path, charts: &mut Vec<Chart>, services: &mut Vec<Service>) -> K8sInventory {
     let mut inv = K8sInventory::default();
     let helm_dirs = collect_helm_dirs(root);
 
@@ -146,7 +142,9 @@ fn collect_helm_dirs(root: &Path) -> Vec<PathBuf> {
         .filter_map(Result::ok)
         .filter(|e| {
             e.file_type().is_file()
-                && e.file_name().to_string_lossy().eq_ignore_ascii_case("chart.yaml")
+                && e.file_name()
+                    .to_string_lossy()
+                    .eq_ignore_ascii_case("chart.yaml")
         })
         .filter_map(|e| e.path().parent().map(Path::to_path_buf))
         .collect()
@@ -251,7 +249,10 @@ pub fn analyze(inv: &K8sInventory, charts: &mut [Chart], engine: &RuleEngine) {
             related.push(np_idx);
             if has_open_egress(&np.doc) {
                 chart.risk.set_flag("hasInternetEgress", true);
-                chart.risk.applied_rule_ids.push("k8s-netpol-open-egress".to_string());
+                chart
+                    .risk
+                    .applied_rule_ids
+                    .push("k8s-netpol-open-egress".to_string());
                 chart.risk.exposure_paths.push(format!(
                     "NetworkPolicy/{} egress 0.0.0.0/0 ← {}/{}",
                     np.name, workload.kind, workload.name
@@ -423,11 +424,19 @@ fn print_profile(chart: &Chart) {
     );
     println!(
         "      • Privileged         : {}",
-        if chart.risk.is_privileged { "YES" } else { "NO" }
+        if chart.risk.is_privileged {
+            "YES"
+        } else {
+            "NO"
+        }
     );
     println!(
         "      • Internet Egress    : {}",
-        if chart.risk.has_internet_egress { "YES" } else { "NO" }
+        if chart.risk.has_internet_egress {
+            "YES"
+        } else {
+            "NO"
+        }
     );
     for path in &chart.risk.exposure_paths {
         println!("      ⇢ EXPOSURE PATH: {}", path);
@@ -504,15 +513,13 @@ spec:
 
     #[test]
     fn open_egress_detection() {
-        let open = yaml(
-            "spec:\n  egress:\n    - to:\n        - ipBlock:\n            cidr: 0.0.0.0/0\n",
-        );
+        let open =
+            yaml("spec:\n  egress:\n    - to:\n        - ipBlock:\n            cidr: 0.0.0.0/0\n");
         assert!(has_open_egress(&open));
         let unrestricted = yaml("spec:\n  egress:\n    - {}\n");
         assert!(has_open_egress(&unrestricted));
-        let closed = yaml(
-            "spec:\n  egress:\n    - to:\n        - ipBlock:\n            cidr: 10.0.0.0/8\n",
-        );
+        let closed =
+            yaml("spec:\n  egress:\n    - to:\n        - ipBlock:\n            cidr: 10.0.0.0/8\n");
         assert!(!has_open_egress(&closed));
         let none = yaml("spec: {}\n");
         assert!(!has_open_egress(&none));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -23,7 +23,9 @@ pub fn print_banner() {
     }
 
     println!();
-    println!("   \x1b[38;5;250m[+] MODULE: \x1b[38;5;129mPRIORITIZER\x1b[0m \x1b[38;5;250mONLINE\x1b[0m");
+    println!(
+        "   \x1b[38;5;250m[+] MODULE: \x1b[38;5;129mPRIORITIZER\x1b[0m \x1b[38;5;250mONLINE\x1b[0m"
+    );
     println!();
 }
 
@@ -33,7 +35,9 @@ pub fn print_phase(phase: &str, description: &str) {
         phase
     );
     println!("\x1b[94m│ \x1b[0m\x1b[2m{}\x1b[0m", description);
-    println!("\x1b[94m└────────────────────────────────────────────────────────────────────\x1b[0m");
+    println!(
+        "\x1b[94m└────────────────────────────────────────────────────────────────────\x1b[0m"
+    );
 }
 
 pub fn print_success(message: &str) {
@@ -92,7 +96,10 @@ pub fn print_match(
     };
 
     // Print finding in a clean, simple format
-    println!("   \x1b[96m▸\x1b[0m \x1b[1m{}\x1b[0m | \x1b[93m{}\x1b[0m", service, cve_id);
+    println!(
+        "   \x1b[96m▸\x1b[0m \x1b[1m{}\x1b[0m | \x1b[93m{}\x1b[0m",
+        service, cve_id
+    );
     println!("     \x1b[2m{}\x1b[0m", full_path);
     println!("     \x1b[2m{}\x1b[0m", description);
     println!(
@@ -109,7 +116,9 @@ pub fn print_help() {
     println!("  \x1b[96m-p, --path\x1b[0m          Path to the source repository \x1b[2m(Required)\x1b[0m");
     println!("  \x1b[96m-s, --sarif\x1b[0m         Path to input SARIF file \x1b[2m(Required unless --scan-only)\x1b[0m");
     println!("  \x1b[96m-o, --output\x1b[0m        Path to save the output JSON report");
-    println!("  \x1b[96m    --sarif-output\x1b[0m  Path to save enriched SARIF \x1b[2m(optional)\x1b[0m");
+    println!(
+        "  \x1b[96m    --sarif-output\x1b[0m  Path to save enriched SARIF \x1b[2m(optional)\x1b[0m"
+    );
     println!("  \x1b[96m    --scan-only\x1b[0m     Perform exposure analysis only \x1b[2m(ignores SARIF)\x1b[0m");
     println!("  \x1b[96m    --rules\x1b[0m         Base directory containing rule sets \x1b[2m(default: ./rules or next to the binary)\x1b[0m");
     println!("  \x1b[96m    --graph\x1b[0m         Path to save an exposure graph \x1b[2m(Mermaid flowchart)\x1b[0m");
@@ -118,7 +127,9 @@ pub fn print_help() {
     println!("  \x1b[2m# Full analysis with SARIF input\x1b[0m");
     println!("  \x1b[32m./reticulum -p ./src -s results.sarif\x1b[0m\n");
     println!("  \x1b[2m# Generate enriched SARIF output\x1b[0m");
-    println!("  \x1b[32m./reticulum -p ./src -s results.sarif --sarif-output enriched.sarif\x1b[0m\n");
+    println!(
+        "  \x1b[32m./reticulum -p ./src -s results.sarif --sarif-output enriched.sarif\x1b[0m\n"
+    );
     println!("  \x1b[2m# Exposure analysis only\x1b[0m");
     println!("  \x1b[32m./reticulum -p ./src --scan-only -o exposure.json\x1b[0m\n");
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -4,8 +4,12 @@ pub fn print_banner() {
     // Header bar - full width tactical style (Purple background, black text)
     print!("\x1b[48;5;129m\x1b[38;5;232m\x1b[1m CLOUD-NATIVE CONTEXTUAL SECURITY PRIORITIZER BY PLEXICUS ");
     println!("                    \x1b[0m");
-    print!("\x1b[100m\x1b[30m RETICULUM v1.0 ");
-    println!("                                                                \x1b[0m\n");
+    let version_tag = format!(" RETICULUM v{} ", env!("CARGO_PKG_VERSION"));
+    print!("\x1b[100m\x1b[30m{}", version_tag);
+    println!(
+        "{}\x1b[0m\n",
+        " ".repeat(80usize.saturating_sub(version_tag.len()))
+    );
 
     // RETICULUM logo in ANSI Shadow font
     const LOGO: [&str; 6] = [


### PR DESCRIPTION
## Summary

Follow-up to #1 (merged) with the release infrastructure:

- **CI workflow** (`.github/workflows/ci.yml`): rustfmt check, `clippy -D warnings`, tests, release build, two end-to-end smoke checks (K8s exposure traceability on monorepo-08, SARIF scoring on monorepo-06) and a Docker build+run smoke — closing the pending item from #1's test plan.
- **Release workflow** (`.github/workflows/release.yml`): on `v*` tag push — binaries for linux/darwin × amd64/arm64 (with bundled `rules/`, README, RULES.md, LICENSE and sha256 checksums), multi-arch Docker image to `ghcr.io/plexicus/reticulum`, and a GitHub Release with generated notes.
- **Version 2.0.0**: `Cargo.toml` is the single source of truth; the banner now reads `CARGO_PKG_VERSION` (was hardcoded "v1.0").
- **CHANGELOG.md**: full 2.0.0 notes (features, the 13 audit fixes, intentional output changes) + 1.0.0 baseline.
- **build_release.sh fix**: it labeled any host build as `linux-amd64` (a macOS/ARM build got a Linux name); now it detects the real OS/arch and emits a checksum.
- rustfmt applied across the crate (now enforced by CI).

## Test plan
- [x] `cargo test` (69), `cargo clippy -- -D warnings`, `cargo fmt --check`
- [x] Both workflows parse as valid YAML
- [x] `build_release.sh` produces `reticulum-v2.0.0-darwin-arm64.tar.gz` with rules bundled
- [x] Banner renders `RETICULUM v2.0.0`
- [ ] Local `docker build` smoke (running; will comment result)

## After merge
Tagging `v2.0.0` on master will trigger the first automated release (binaries + GHCR image).