### PR TITLE
[Fix] Exposure-score inversion: public ClusterIP no longer scores below an orphan

### DIFF
--- a/RESULTS.md
+++ b/RESULTS.md
@@ -22,7 +22,7 @@ This document details the performance of Reticulum across multiple test monorepo
 - **Escalated:** 0%
 - **Avg Score Reduction:** -24.5 pts
 
-**Insight:** Even though `payment-api` is public, Reticulum lowered its score because it lacks other risk factors (privileged, root), making the "High" tool scores disproportionate to the actual risk.
+**Insight:** `payment-api` is public via Ingress, so its MEDIUM-severity findings are boosted (score 50 → 65) rather than lowered — public exposure raises priority even without other risk factors (privileged, root). Contrast with `payment-worker`, which stays internal-only and gets de-prioritized as expected.
 
 ---
 

--- a/rules/scoring/internal.yaml
+++ b/rules/scoring/internal.yaml
@@ -1,6 +1,6 @@
 id: "scoring-internal"
 name: "Internal Service Scoring"
-description: "Applies penalty for internal services (default)"
+description: "Applies penalty for internal services (default). Skipped by the engine when a public-exposure rule already confirmed this service is reachable (see RuleEngine::evaluate_values)."
 severity: "info"
 tags: ["scoring", "internal"]
 target: "values"

--- a/src/rules/engine.rs
+++ b/src/rules/engine.rs
@@ -78,6 +78,22 @@ impl RuleEngine {
             if rule.target != RuleTarget::Values {
                 continue;
             }
+            // AUDIT FIX: `rules/exposure/*.yaml` always sorts before
+            // `rules/scoring/*.yaml` (directory load order), so a confirmed
+            // public-exposure rule (isPublic + x1.3+) has already run by the
+            // time an internal-service de-prioritizer (e.g. ClusterIP x0.5)
+            // is checked. Combining both nets a multiplier below neutral,
+            // scoring a publicly exposed service *below* an unexposed
+            // orphan. Once exposure is confirmed, de-prioritizers must not
+            // fire for that same service.
+            let is_deprioritizer = rule
+                .action
+                .risk_profile
+                .score_multiplier
+                .is_some_and(|m| m < 1.0);
+            if is_deprioritizer && chart.risk.is_public {
+                continue;
+            }
             if rule.matches_with(|m| check_values_match(values, m)) {
                 apply_action(chart, rule);
             }
@@ -830,5 +846,61 @@ action:
             "properties": {"trivy:packageName": "openssl-dev"}
         }));
         assert!(!engine.evaluate_finding(&mut f, &chart));
+    }
+
+    #[test]
+    fn public_clusterip_service_is_not_deprioritized_below_orphan() {
+        // AUDIT FIX regression: Ingress (x1.3, sets isPublic) + ClusterIP
+        // internal de-prioritizer (x0.5) used to combine into 0.65, scoring
+        // a publicly exposed service below an unexposed orphan.
+        let engine = engine_from(
+            r#"
+id: "exposure-ingress-enabled"
+name: "Public Ingress Exposure"
+target: "values"
+match:
+  - key: "ingress.enabled"
+    op: "eq"
+    value: true
+  - key: "ingress.hosts"
+    op: "exists"
+action:
+  risk_profile:
+    set_flag: "isPublic"
+    score_multiplier: 1.3
+---
+id: "scoring-internal"
+name: "Internal Service Scoring"
+target: "values"
+match:
+  - key: "service.type"
+    op: "eq"
+    value: "ClusterIP"
+action:
+  risk_profile:
+    score_multiplier: 0.5
+"#,
+        );
+        let mut chart = Chart::new("payment-api", "/tmp/payment-api");
+        let values = yaml(
+            "ingress:\n  enabled: true\n  hosts:\n    - api.payments.com\nservice:\n  type: ClusterIP\n",
+        );
+        engine.evaluate_values(&mut chart, &values);
+
+        assert!(chart.risk.is_public);
+        // The ClusterIP de-prioritizer must not have fired once exposure was confirmed.
+        assert_eq!(chart.risk.multipliers, vec![1.3]);
+        assert_eq!(
+            chart.risk.applied_rule_ids,
+            vec!["exposure-ingress-enabled"]
+        );
+
+        let orphan_score = crate::model::RiskProfile::default().calculate_score(75);
+        let public_score = chart.risk.calculate_score(75);
+        assert!(public_score >= 75);
+        assert!(
+            public_score > orphan_score,
+            "Ingress-exposed ClusterIP ({public_score}) must score strictly higher than an orphan ({orphan_score})"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `rules/exposure/ingress.yaml` (x1.3, sets `isPublic`) and `rules/scoring/internal.yaml` (ClusterIP x0.5) could both fire on the same Helm-sourced service. Combined they net a 0.65 multiplier, so a publicly exposed service (e.g. an Ingress-fronted ClusterIP) scored *below* an unexposed orphan (neutral 1.0). `RESULTS.md`'s Monorepo 01 narrative even documented this as if it were intended behavior.
- `RuleEngine::evaluate_values` (`src/rules/engine.rs`) now skips any `values`-target de-prioritizer rule (`score_multiplier < 1.0`) once a public-exposure rule has already set `chart.risk.is_public` earlier in the same pass. This holds because `rules/exposure/*.yaml` always sorts/loads before `rules/scoring/*.yaml`, so exposure rules (Ingress, Ambassador, Emissary, Gateway API, Istio) always evaluate first.
- Updated `rules/scoring/internal.yaml`'s description to document the new gating behavior.
- Corrected the `RESULTS.md` "Monorepo 01" insight, which previously described the buggy score reduction as a feature.

## Verification
- `cargo test` — 70/70 passing, including a new regression test (`public_clusterip_service_is_not_deprioritized_below_orphan`) reproducing the exact Ingress+ClusterIP combo and asserting the de-prioritizer no longer fires, and that the resulting score is strictly greater than an orphan's.
- `cargo fmt --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo build --release` + real e2e run against `tests/monorepo-06` (`-s tests/fixtures/synthetic-trivy.sarif`): scores unchanged (`admin-api:100, internal-worker:49, payment-go:22, postgres-db:35`) — none of those services hit the ClusterIP+exposure combo, so no snapshot re-baseline was needed there.
- `cargo build --release` + real e2e run against `tests/monorepo-01` (`--scan-only`): `payment-api`'s `baseRiskScore` is now `65` (50 × 1.3, ClusterIP de-prioritizer correctly skipped) and `appliedRuleIds` only contains `exposure-ingress-enabled` — matching the score `tests/monorepo-01/README.md` already documented as the *expected* value.

## Test plan
- [x] `cargo test`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release` + manual e2e smoke against `tests/monorepo-06` and `tests/monorepo-01`