### PR TITLE
[Fix] Exit non-zero on missing SARIF path, count unmatched findings

### DIFF
--- a/src/ingestor.rs
+++ b/src/ingestor.rs
@@ -232,6 +232,17 @@ fn extract_file_path(result: &Value) -> String {
         .to_string()
 }
 
+/// Outcome of a SARIF ingestion pass, surfaced in the JSON report and used
+/// by the caller to decide the process exit code.
+#[derive(Debug, Default)]
+pub struct SarifIngestResult {
+    /// The `--sarif` path did not exist on disk.
+    pub sarif_missing: bool,
+    /// Number of SARIF results whose path did not resolve inside any known
+    /// service directory (silently dropped before this fix).
+    pub unmatched_findings: usize,
+}
+
 pub fn process_sarif(
     filename: &str,
     services: &mut [Service],
@@ -239,9 +250,13 @@ pub fn process_sarif(
     repo_path: &Path,
     engine: &RuleEngine,
     sarif_output: Option<&str>,
-) {
+) -> SarifIngestResult {
     if !Path::new(filename).exists() {
-        return;
+        ui::print_error(&format!("SARIF file not found: {}", filename));
+        return SarifIngestResult {
+            sarif_missing: true,
+            unmatched_findings: 0,
+        };
     }
 
     println!("=== Processing SARIF file: {} ===", filename);
@@ -249,22 +264,23 @@ pub fn process_sarif(
         Ok(c) => c,
         Err(e) => {
             ui::print_error(&format!("Error reading SARIF file: {}", e));
-            return;
+            return SarifIngestResult::default();
         }
     };
     let mut sarif: Value = match serde_json::from_str(&content) {
         Ok(j) => j,
         Err(e) => {
             ui::print_error(&format!("Error parsing SARIF file: {}", e));
-            return;
+            return SarifIngestResult::default();
         }
     };
 
     let mut first_finding = true;
+    let mut unmatched_findings: usize = 0;
 
     let runs = match sarif.get_mut("runs").and_then(|r| r.as_array_mut()) {
         Some(r) => r,
-        None => return,
+        None => return SarifIngestResult::default(),
     };
 
     for run in runs.iter_mut() {
@@ -295,6 +311,8 @@ pub fn process_sarif(
             let file_path = extract_file_path(result);
             let finding_path = resolve_finding_path(&file_path, repo_path);
 
+            let mut matched_service = false;
+
             for service in services.iter_mut() {
                 let svc_dir = normalize(Path::new(&service.directory));
                 let svc_docker = normalize(Path::new(&service.dockerfile_path));
@@ -303,6 +321,7 @@ pub fn process_sarif(
                 if !is_inside {
                     continue;
                 }
+                matched_service = true;
 
                 let chart = service.chart.map(|idx| &charts[idx]);
 
@@ -372,6 +391,10 @@ pub fn process_sarif(
 
                 service.findings.push(f);
             }
+
+            if !matched_service {
+                unmatched_findings += 1;
+            }
         }
     }
 
@@ -384,6 +407,18 @@ pub fn process_sarif(
             },
             Err(e) => println!("Error serializing SARIF output: {}", e),
         }
+    }
+
+    if unmatched_findings > 0 {
+        ui::print_warning(&format!(
+            "{} SARIF result(s) resolved outside every known service directory and were not scored",
+            unmatched_findings
+        ));
+    }
+
+    SarifIngestResult {
+        sarif_missing: false,
+        unmatched_findings,
     }
 }
 
@@ -505,5 +540,89 @@ mod tests {
         // AUDIT FIX regression test: "/repo/app-extra" is NOT inside "/repo/app"
         let p = PathBuf::from("/repo/app-extra/file.py");
         assert!(!p.starts_with(Path::new("/repo/app")));
+    }
+
+    #[test]
+    fn missing_sarif_file_is_reported_and_no_findings_ingested() {
+        // H76: a missing --sarif path must be surfaced (and the caller
+        // exits non-zero), instead of silently returning as a no-op.
+        let mut services = vec![Service::new("svc", "svc/Dockerfile", "svc")];
+        let charts: Vec<Chart> = Vec::new();
+        let engine = RuleEngine::new();
+        let repo = std::env::temp_dir().join("reticulum-ingestor-missing-sarif-test");
+
+        let result = process_sarif(
+            "/nonexistent/path/does-not-exist.sarif",
+            &mut services,
+            &charts,
+            &repo,
+            &engine,
+            None,
+        );
+
+        assert!(result.sarif_missing);
+        assert_eq!(result.unmatched_findings, 0);
+        assert!(services[0].findings.is_empty());
+    }
+
+    #[test]
+    fn result_outside_every_service_dir_is_counted_as_unmatched() {
+        // H76: a SARIF result whose path resolves outside every known
+        // service directory must be counted, not silently dropped.
+        let repo = std::env::temp_dir().join("reticulum-ingestor-unmatched-test");
+        let _ = fs::remove_dir_all(&repo);
+        fs::create_dir_all(repo.join("svc")).unwrap();
+        fs::write(repo.join("svc/app.py"), "x").unwrap();
+        let repo = normalize(&repo);
+        let svc_dir = repo.join("svc");
+
+        let sarif_path = repo.join("results.sarif");
+        let sarif = json!({
+            "runs": [{
+                "tool": {"driver": {"rules": []}},
+                "results": [
+                    {
+                        "ruleId": "matched-rule",
+                        "level": "error",
+                        "locations": [{"physicalLocation": {
+                            "artifactLocation": {"uri": "svc/app.py"},
+                            "region": {"startLine": 1}
+                        }}]
+                    },
+                    {
+                        "ruleId": "unmatched-rule",
+                        "level": "error",
+                        "locations": [{"physicalLocation": {
+                            "artifactLocation": {"uri": "outside/app.py"},
+                            "region": {"startLine": 1}
+                        }}]
+                    }
+                ]
+            }]
+        });
+        fs::write(&sarif_path, serde_json::to_string(&sarif).unwrap()).unwrap();
+
+        let mut services = vec![Service::new(
+            "svc",
+            svc_dir.join("Dockerfile").to_str().unwrap(),
+            svc_dir.to_str().unwrap(),
+        )];
+        let charts: Vec<Chart> = Vec::new();
+        let engine = RuleEngine::new();
+
+        let result = process_sarif(
+            sarif_path.to_str().unwrap(),
+            &mut services,
+            &charts,
+            &repo,
+            &engine,
+            None,
+        );
+
+        assert!(!result.sarif_missing);
+        assert_eq!(result.unmatched_findings, 1);
+        assert_eq!(services[0].findings.len(), 1);
+
+        let _ = fs::remove_dir_all(&repo);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,18 +111,34 @@ fn write_graph(args: &Args, m: &Mapper) {
     }
 }
 
-fn build_report(m: &Mapper, scan_type: &str) -> Value {
+fn build_report(
+    m: &Mapper,
+    scan_type: &str,
+    ingest: Option<&ingestor::SarifIngestResult>,
+) -> Value {
     let services: Vec<Value> = m
         .services
         .iter()
         .map(|s| s.to_json(s.chart.map(|idx| &m.charts[idx])))
         .collect();
 
-    json!({
+    let mut root = json!({
         "services": services,
         "totalServices": m.services.len(),
         "scanType": scan_type,
-    })
+    });
+
+    if let Some(ingest) = ingest {
+        root["unmatchedFindings"] = json!(ingest.unmatched_findings);
+        if ingest.unmatched_findings > 0 {
+            root["warnings"] = json!([format!(
+                "{} SARIF result(s) resolved outside every known service directory and were not scored",
+                ingest.unmatched_findings
+            )]);
+        }
+    }
+
+    root
 }
 
 fn write_json_report(path: &str, root: &Value, success_msg: &str) {
@@ -212,7 +228,7 @@ fn main() -> ExitCode {
         ui::print_warning("Mode: Exposure Analysis Only (Skipping SARIF ingestion)");
 
         write_graph(&args, &m);
-        let root = build_report(&m, "exposure-audit");
+        let root = build_report(&m, "exposure-audit", None);
         match args.output.as_deref() {
             Some(out) if !out.is_empty() => {
                 write_json_report(out, &root, "Exposure report saved to")
@@ -230,7 +246,7 @@ fn main() -> ExitCode {
         "Ingesting SARIF and applying contextual scoring",
     );
     let sarif_input = args.sarif.as_deref().unwrap_or("");
-    ingestor::process_sarif(
+    let ingest_result = ingestor::process_sarif(
         sarif_input,
         &mut m.services,
         &m.charts,
@@ -239,11 +255,15 @@ fn main() -> ExitCode {
         args.sarif_output.as_deref().filter(|s| !s.is_empty()),
     );
 
+    if ingest_result.sarif_missing {
+        return ExitCode::FAILURE;
+    }
+
     write_graph(&args, &m);
 
     // --- Generate JSON Report (Full Scan) ---
     if let Some(out) = args.output.as_deref().filter(|s| !s.is_empty()) {
-        let root = build_report(&m, "full-analysis");
+        let root = build_report(&m, "full-analysis", Some(&ingest_result));
         write_json_report(out, &root, "Full analysis report saved to");
     }
 


### PR DESCRIPTION
## Summary

- `process_sarif` silently returned when the `--sarif` file didn't exist, leaving the process exit code at `0` — CI callers couldn't distinguish "clean scan" from "the scanner never ran."
- A SARIF result whose path didn't resolve inside any known service directory was dropped without a trace (no counter, no log line beyond the per-match print).

## Changes

- `src/ingestor.rs`: `process_sarif` now returns a `SarifIngestResult { sarif_missing, unmatched_findings }` instead of `()`. The missing-file branch logs an error and sets `sarif_missing = true`. The per-result service-matching loop tracks whether any service matched and increments `unmatched_findings` when none did.
- `src/main.rs`: `main()` exits `ExitCode::FAILURE` when `sarif_missing` is true. `build_report` takes an `Option<&SarifIngestResult>` and, when present, adds `unmatchedFindings` (and `warnings` when non-zero) to the JSON report. `--scan-only` passes `None`, so its report/output is unaffected.

## Verify

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — 71/71 passing, including two new inline `#[cfg(test)]` cases: a missing `--sarif` path returns `sarif_missing=true` with no findings ingested, and a result outside every service dir is counted as `unmatched_findings=1` while a real match still lands on the correct service.
- `cargo build --release` + CI's own smoke checks reproduced locally:
  - `--scan-only` on `tests/monorepo-08`: JSON report and Mermaid graph are byte-identical to the pre-change binary (only the absolute repo-path prefix in `directory` differs, due to running from a different worktree location).
  - Full SARIF run on `tests/monorepo-06`: scores unchanged (`admin-api=100, internal-worker=49, payment-go=22, postgres-db=35`), `unmatchedFindings=0`.
  - Missing `--sarif` path now exits `1` (previously `0`).

Card H76 from the platform deep-audit remediation wave.