### PR TITLE
[Fix] Add --env precedence selector and --include/--exclude path allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,29 @@ jobs:
           print("monorepo-06 scoring OK", scores)
           EOF
 
+      - name: End-to-end smoke (env selector + path allowlist)
+        run: |
+          ./target/release/reticulum -p tests/monorepo-10 --scan-only -o /tmp/scan-10-union.json
+          ./target/release/reticulum -p tests/monorepo-10 --scan-only --env prod -o /tmp/scan-10-prod.json
+          ./target/release/reticulum -p tests/monorepo-10 --scan-only --exclude "examples/**" -o /tmp/scan-10-excluded.json
+          python3 - <<'EOF'
+          import json
+
+          union = {s["id"]: s for s in json.load(open("/tmp/scan-10-union.json"))["services"]}
+          prod = {s["id"]: s for s in json.load(open("/tmp/scan-10-prod.json"))["services"]}
+          excluded = {s["id"]: s for s in json.load(open("/tmp/scan-10-excluded.json"))["services"]}
+
+          # No --env: union of every overlay — dev's ingress.enabled leaks in.
+          assert union["internal-api"]["riskProfile"]["isPublic"], "union must merge the dev overlay"
+          # --env prod: only base + prod overlay considered — stays internal.
+          assert not prod["internal-api"]["riskProfile"]["isPublic"], "prod-only view must stay internal"
+          # No --exclude: the examples/ decoy is discovered like any other manifest.
+          assert union["decoy-workload"]["riskProfile"]["isPrivileged"]
+          # --exclude examples/**: the decoy never contributes a service.
+          assert "decoy-workload" not in excluded, "excluded path must not contribute a service"
+          print("monorepo-10 env selector + path allowlist OK")
+          EOF
+
   docker:
     name: Docker build
     runs-on: ubuntu-latest

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -6,7 +6,7 @@ use serde_yaml::Value as Yaml;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-pub fn analyze_exposure(chart: &mut Chart, engine: &RuleEngine) {
+pub fn analyze_exposure(chart: &mut Chart, engine: &RuleEngine, env: Option<&str>) {
     println!(
         "  [Analyzer] Analyzing chart: {} → {}",
         chart.name, chart.path
@@ -16,7 +16,7 @@ pub fn analyze_exposure(chart: &mut Chart, engine: &RuleEngine) {
     // 1. Evaluate Metadata Rules
     engine.evaluate_metadata(chart);
 
-    let mut value_files = collect_value_files(Path::new(&chart.path));
+    let mut value_files = collect_value_files(Path::new(&chart.path), env);
     value_files.sort();
 
     for path in value_files {
@@ -58,8 +58,33 @@ pub fn analyze_exposure(chart: &mut Chart, engine: &RuleEngine) {
     );
 }
 
+/// Environment tags recognized in overlay file names (`values-prod.yaml`,
+/// `values.staging.yaml`, the legacy bare `dev.yaml`, ...). An unrecognized
+/// tag (e.g. `values-secrets.yaml`) is treated as an untagged overlay and
+/// stays in scope regardless of `--env`, so a custom, non-environment
+/// overlay is never silently dropped.
+const KNOWN_ENV_TOKENS: [&str; 11] = [
+    "prod",
+    "production",
+    "staging",
+    "stage",
+    "dev",
+    "development",
+    "test",
+    "testing",
+    "qa",
+    "uat",
+    "sandbox",
+];
+
 /// Select candidate values files in the chart directory (shallow scan).
-fn collect_value_files(chart_dir: &Path) -> Vec<PathBuf> {
+///
+/// With `env: None` every discovered overlay is analyzed — today's union,
+/// kept as the default for back-compat. With `env: Some(name)`, only the
+/// base `values.yaml`/`values.yml` plus the overlay tagged for that single
+/// environment are analyzed, so exposure reflects one deployed topology
+/// instead of the union of every environment ever committed.
+fn collect_value_files(chart_dir: &Path, env: Option<&str>) -> Vec<PathBuf> {
     let mut value_files = Vec::new();
     let entries = match fs::read_dir(chart_dir) {
         Ok(e) => e,
@@ -81,19 +106,48 @@ fn collect_value_files(chart_dir: &Path) -> Vec<PathBuf> {
             continue;
         }
 
-        // Allow standard values.yaml, variations like values-prod.yaml,
-        // or specific environment files
-        let is_yaml = fname.ends_with(".yaml") || fname.ends_with(".yml");
-        let looks_like_values = fname.starts_with("values")
-            || fname == "prod.yaml"
-            || fname == "staging.yaml"
-            || fname == "dev.yaml";
+        if !(fname.ends_with(".yaml") || fname.ends_with(".yml")) {
+            continue;
+        }
 
-        if is_yaml && looks_like_values {
-            value_files.push(entry.path());
+        match classify_values_file(&fname) {
+            None => {}                                    // not a values file at all
+            Some(None) => value_files.push(entry.path()), // base / untagged overlay — always in scope
+            Some(Some(tag)) => {
+                let in_scope = match env {
+                    None => true, // no selector — today's union
+                    Some(selected) => tag.eq_ignore_ascii_case(selected),
+                };
+                if in_scope {
+                    value_files.push(entry.path());
+                }
+            }
         }
     }
     value_files
+}
+
+/// Classify a lowercased values-file name as: not a values file (`None`), an
+/// untagged values file (`Some(None)`), or a recognized environment overlay
+/// (`Some(Some(tag))`).
+fn classify_values_file(fname: &str) -> Option<Option<String>> {
+    let stem = fname.rsplit_once('.').map(|(s, _)| s).unwrap_or(fname);
+
+    let tag = if fname == "prod.yaml" || fname == "staging.yaml" || fname == "dev.yaml" {
+        Some(stem.to_string())
+    } else if fname.starts_with("values") {
+        stem[("values".len())..]
+            .strip_prefix(['-', '.', '_'])
+            .filter(|t| !t.is_empty())
+            .map(|t| t.to_string())
+    } else {
+        return None;
+    };
+
+    match tag {
+        Some(t) if KNOWN_ENV_TOKENS.contains(&t.as_str()) => Some(Some(t)),
+        _ => Some(None),
+    }
 }
 
 fn analyze_values_file(chart: &mut Chart, path: &Path, engine: &RuleEngine) {
@@ -147,7 +201,8 @@ mod tests {
             fs::write(dir.join(name), "x: 1\n").unwrap();
         }
 
-        let mut files: Vec<String> = collect_value_files(&dir)
+        // No --env selector: every discovered overlay is in scope (union, back-compat).
+        let mut files: Vec<String> = collect_value_files(&dir, None)
             .into_iter()
             .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
             .collect();
@@ -155,5 +210,67 @@ mod tests {
         assert_eq!(files, vec!["prod.yaml", "values-prod.yaml", "values.yaml"]);
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn env_selector_excludes_other_environment_overlays() {
+        let dir = std::env::temp_dir().join("reticulum-analyzer-env-test");
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        for name in [
+            "values.yaml",
+            "values-prod.yaml",
+            "values-dev.yaml",
+            "values-secrets.yaml",
+        ] {
+            fs::write(dir.join(name), "x: 1\n").unwrap();
+        }
+
+        let mut prod_only: Vec<String> = collect_value_files(&dir, Some("prod"))
+            .into_iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        prod_only.sort();
+        // dev overlay is excluded; base + untagged secrets overlay stay in scope.
+        assert_eq!(
+            prod_only,
+            vec!["values-prod.yaml", "values-secrets.yaml", "values.yaml"]
+        );
+
+        let mut union: Vec<String> = collect_value_files(&dir, None)
+            .into_iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().to_string())
+            .collect();
+        union.sort();
+        assert_eq!(
+            union,
+            vec![
+                "values-dev.yaml",
+                "values-prod.yaml",
+                "values-secrets.yaml",
+                "values.yaml"
+            ]
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn classify_recognizes_tagged_and_untagged_overlays() {
+        assert_eq!(classify_values_file("values.yaml"), Some(None));
+        assert_eq!(
+            classify_values_file("values-prod.yaml"),
+            Some(Some("prod".to_string()))
+        );
+        assert_eq!(
+            classify_values_file("values.staging.yaml"),
+            Some(Some("staging".to_string()))
+        );
+        assert_eq!(
+            classify_values_file("dev.yaml"),
+            Some(Some("dev".to_string()))
+        );
+        assert_eq!(classify_values_file("values-secrets.yaml"), Some(None));
+        assert_eq!(classify_values_file("notes.yaml"), None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,14 @@ mod graph;
 mod ingestor;
 mod mapper;
 mod model;
+mod pathfilter;
 mod rules;
 mod sources;
 mod ui;
 
 use clap::Parser;
 use mapper::Mapper;
+use pathfilter::PathFilter;
 use rules::RuleEngine;
 use serde_json::{json, Value};
 use std::fs;
@@ -51,6 +53,28 @@ struct Args {
     /// Path to save an exposure graph (Mermaid flowchart)
     #[arg(long = "graph")]
     graph: Option<String>,
+
+    /// Analyze a single deployed environment: base values.yaml/values.yml
+    /// plus only the overlay tagged for this environment (e.g. `prod`).
+    /// Default (omitted): merge every discovered environment overlay,
+    /// matching pre-selector behavior.
+    #[arg(long = "env")]
+    env: Option<String>,
+
+    /// Only analyze paths matching this glob, relative to --path (repeatable,
+    /// supports `*`, `**`, `?`). Default: no restriction.
+    #[arg(long = "include")]
+    include: Vec<String>,
+
+    /// Skip paths matching this glob, relative to their walk root
+    /// (repeatable; always wins over --include).
+    #[arg(long = "exclude")]
+    exclude: Vec<String>,
+
+    /// Additional external gitops root (e.g. a separate deploy repo) to scan
+    /// for Helm charts and Kubernetes manifests alongside --path.
+    #[arg(long = "gitops-root")]
+    gitops_root: Option<String>,
 
     /// This help information
     #[arg(short = 'h', long = "help")]
@@ -172,6 +196,20 @@ fn main() -> ExitCode {
     };
     ui::print_info(&format!("Target Repository: {}", abs_repo_path.display()));
 
+    // Optional external gitops root (e.g. a separate deploy repo), scanned
+    // alongside --path for Helm charts / Kubernetes manifests.
+    let gitops_root = match args.gitops_root.as_deref().filter(|s| !s.is_empty()) {
+        Some(p) => match fs::canonicalize(p) {
+            Ok(abs) => Some(abs),
+            Err(e) => {
+                ui::print_error(&format!("Cannot resolve --gitops-root '{}': {}", p, e));
+                return ExitCode::FAILURE;
+            }
+        },
+        None => None,
+    };
+    let filter = PathFilter::new(&args.include, &args.exclude);
+
     // --- Initialize Rule Engine ---
     ui::print_info("Initializing Rule Engine...");
     let mut engine = RuleEngine::new();
@@ -184,10 +222,24 @@ fn main() -> ExitCode {
         "Phase 1: Service Discovery",
         "Mapping services, Helm charts, K8s manifests and compose stacks",
     );
+    // Every root scanned for charts/manifests: the source repo, plus an
+    // optional external gitops root (kept separate from the SARIF/report
+    // repo path, which always stays `abs_repo_path`).
+    let mut disc_roots = vec![abs_repo_path.clone()];
+    if let Some(g) = &gitops_root {
+        disc_roots.push(g.clone());
+    }
+
     let mut m = Mapper::new();
-    m.walk(&abs_repo_path);
-    let k8s_inv = sources::k8s::discover(&abs_repo_path, &mut m.charts, &mut m.services);
-    let compose_inv = sources::compose::discover(&abs_repo_path, &mut m.charts, &mut m.services);
+    for root in &disc_roots {
+        m.walk(root, &filter);
+    }
+    let k8s_invs: Vec<sources::k8s::K8sInventory> = disc_roots
+        .iter()
+        .map(|root| sources::k8s::discover(root, &mut m.charts, &mut m.services, &filter))
+        .collect();
+    let compose_inv =
+        sources::compose::discover(&abs_repo_path, &mut m.charts, &mut m.services, &filter);
     m.link();
 
     ui::print_phase(
@@ -201,11 +253,13 @@ fn main() -> ExitCode {
         if let Some(idx) = s.chart {
             if !analyzed[idx] && m.charts[idx].source == model::SourceKind::Helm {
                 analyzed[idx] = true;
-                analyzer::analyze_exposure(&mut m.charts[idx], &engine);
+                analyzer::analyze_exposure(&mut m.charts[idx], &engine, args.env.as_deref());
             }
         }
     }
-    sources::k8s::analyze(&k8s_inv, &mut m.charts, &engine);
+    for k8s_inv in &k8s_invs {
+        sources::k8s::analyze(k8s_inv, &mut m.charts, &engine);
+    }
     sources::compose::analyze(&compose_inv, &mut m.charts, &engine);
 
     if args.scan_only {

--- a/src/mapper.rs
+++ b/src/mapper.rs
@@ -1,6 +1,7 @@
 //! Service discovery: walk the repo, find Dockerfiles and Helm charts, link them.
 
 use crate::model::{Chart, Service};
+use crate::pathfilter::{relative_str, PathFilter};
 use serde_yaml::Value as Yaml;
 use std::fs;
 use std::path::Path;
@@ -17,7 +18,7 @@ impl Mapper {
         Mapper::default()
     }
 
-    pub fn walk(&mut self, root_dir: &Path) {
+    pub fn walk(&mut self, root_dir: &Path, filter: &PathFilter) {
         println!("=== Discovery Walk: {} ===", root_dir.display());
         if !root_dir.exists() {
             println!("Error: Root directory does not exist.");
@@ -31,6 +32,9 @@ impl Mapper {
             .filter(|e| e.file_type().is_file())
         {
             let entry_path = entry.path();
+            if !filter.is_allowed(&relative_str(root_dir, entry_path)) {
+                continue;
+            }
             let fname = entry.file_name().to_string_lossy().to_string();
             let fdir = entry_path.parent().unwrap_or(Path::new(""));
             let lower_name = fname.to_lowercase();

--- a/src/pathfilter.rs
+++ b/src/pathfilter.rs
@@ -1,0 +1,138 @@
+//! Path allowlist/denylist for repo discovery walks.
+//!
+//! Patterns are simple shell globs (`*`, `**`, `?`) matched against the
+//! discovered path relative to the walk root, so a decoy directory such as
+//! `examples/` or `tests/fixtures/` can be excluded (or the walk restricted
+//! to an allowlist) without it silently contributing exposure signal.
+//! `--exclude` always wins over `--include`; an empty include list allows
+//! everything that isn't excluded (today's behavior, back-compat).
+
+use regex::Regex;
+use std::path::Path;
+
+#[derive(Debug, Default)]
+pub struct PathFilter {
+    include: Vec<Regex>,
+    exclude: Vec<Regex>,
+}
+
+impl PathFilter {
+    pub fn new(include: &[String], exclude: &[String]) -> PathFilter {
+        PathFilter {
+            include: include.iter().filter_map(|p| glob_to_regex(p)).collect(),
+            exclude: exclude.iter().filter_map(|p| glob_to_regex(p)).collect(),
+        }
+    }
+
+    /// True when `rel_path` (walk-root-relative, `/`-separated) is in scope.
+    pub fn is_allowed(&self, rel_path: &str) -> bool {
+        let included =
+            self.include.is_empty() || self.include.iter().any(|re| re.is_match(rel_path));
+        let excluded = self.exclude.iter().any(|re| re.is_match(rel_path));
+        included && !excluded
+    }
+}
+
+/// `path` relative to `root` as a `/`-separated string, for glob matching.
+pub fn relative_str(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// Translate a shell glob into an anchored regex. `*` matches any run
+/// excluding `/`, `?` matches one char excluding `/`, and `**` matches zero
+/// or more path segments (so `**/x`, `x/**` and `x/**/y` all also match `x`
+/// with the double-star segment collapsed to nothing, not just "anything
+/// incl. `/`" naively concatenated).
+fn glob_to_regex(pattern: &str) -> Option<Regex> {
+    let chars: Vec<char> = pattern.chars().collect();
+    let n = chars.len();
+    let mut re = String::from("^");
+    let mut i = 0;
+    while i < n {
+        // "x/**/y" -> "x(?:/.*)?/y": the double-star segment (with both its
+        // surrounding slashes) may collapse to nothing, still leaving one
+        // mandatory separating slash before the next literal segment.
+        if i + 3 < n
+            && chars[i] == '/'
+            && chars[i + 1] == '*'
+            && chars[i + 2] == '*'
+            && chars[i + 3] == '/'
+        {
+            re.push_str("(?:/.*)?/");
+            i += 4;
+            continue;
+        }
+        // Leading "**/x" -> "(?:.*/)?x": may match zero directories.
+        if i == 0 && i + 2 < n && chars[i] == '*' && chars[i + 1] == '*' && chars[i + 2] == '/' {
+            re.push_str("(?:.*/)?");
+            i += 3;
+            continue;
+        }
+        // Trailing "x/**" -> "x(?:/.*)?": may match nothing past `x`.
+        if i + 3 == n && chars[i] == '/' && chars[i + 1] == '*' && chars[i + 2] == '*' {
+            re.push_str("(?:/.*)?");
+            i += 3;
+            continue;
+        }
+        // Bare "**" elsewhere: any run including `/`.
+        if chars[i] == '*' && i + 1 < n && chars[i + 1] == '*' {
+            re.push_str(".*");
+            i += 2;
+            continue;
+        }
+        match chars[i] {
+            '*' => re.push_str("[^/]*"),
+            '?' => re.push_str("[^/]"),
+            c => re.push_str(&regex::escape(&c.to_string())),
+        }
+        i += 1;
+    }
+    re.push('$');
+    Regex::new(&re).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_star_does_not_cross_segments() {
+        let f = PathFilter::new(&[], &["examples/*".to_string()]);
+        assert!(!f.is_allowed("examples/decoy.yaml"));
+        assert!(f.is_allowed("examples/nested/decoy.yaml"));
+    }
+
+    #[test]
+    fn doublestar_matches_nested_segments() {
+        let f = PathFilter::new(&[], &["**/examples/**".to_string()]);
+        assert!(!f.is_allowed("examples/decoy.yaml"));
+        assert!(!f.is_allowed("apps/svc/examples/nested/decoy.yaml"));
+        assert!(f.is_allowed("apps/svc/values.yaml"));
+    }
+
+    #[test]
+    fn include_allowlist_restricts_to_matches() {
+        let f = PathFilter::new(&["charts/payment-api/**".to_string()], &[]);
+        assert!(f.is_allowed("charts/payment-api/values.yaml"));
+        assert!(!f.is_allowed("charts/other/values.yaml"));
+    }
+
+    #[test]
+    fn exclude_wins_over_include() {
+        let f = PathFilter::new(
+            &["charts/**".to_string()],
+            &["charts/**/examples/**".to_string()],
+        );
+        assert!(f.is_allowed("charts/payment-api/values.yaml"));
+        assert!(!f.is_allowed("charts/payment-api/examples/decoy.yaml"));
+    }
+
+    #[test]
+    fn empty_filter_allows_everything() {
+        let f = PathFilter::new(&[], &[]);
+        assert!(f.is_allowed("anything/at/all.yaml"));
+    }
+}

--- a/src/sources/compose.rs
+++ b/src/sources/compose.rs
@@ -6,6 +6,7 @@
 //! DSL reaches compose stacks too.
 
 use crate::model::{Chart, Service, SourceKind};
+use crate::pathfilter::{relative_str, PathFilter};
 use crate::rules::RuleEngine;
 use serde_yaml::{Mapping, Value as Yaml};
 use std::fs;
@@ -49,6 +50,7 @@ pub fn discover(
     root: &Path,
     charts: &mut Vec<Chart>,
     services: &mut Vec<Service>,
+    filter: &PathFilter,
 ) -> ComposeInventory {
     let mut inv = ComposeInventory::default();
 
@@ -59,6 +61,7 @@ pub fn discover(
         .filter(|e| {
             e.file_type().is_file()
                 && is_compose_file(&e.file_name().to_string_lossy().to_lowercase())
+                && filter.is_allowed(&relative_str(root, e.path()))
         })
         .map(|e| e.into_path())
         .collect();

--- a/src/sources/k8s.rs
+++ b/src/sources/k8s.rs
@@ -10,6 +10,7 @@
 //! exposure chains like `Ingress/web → Service/web-svc → Deployment/web`.
 
 use crate::model::{Chart, Service, SourceKind};
+use crate::pathfilter::{relative_str, PathFilter};
 use crate::rules::RuleEngine;
 use serde_yaml::Value as Yaml;
 use std::collections::HashSet;
@@ -52,7 +53,12 @@ pub struct K8sInventory {
 
 /// Scan for raw manifests, appending one config unit per workload and a
 /// Service entry (for finding attribution) when none exists for that id.
-pub fn discover(root: &Path, charts: &mut Vec<Chart>, services: &mut Vec<Service>) -> K8sInventory {
+pub fn discover(
+    root: &Path,
+    charts: &mut Vec<Chart>,
+    services: &mut Vec<Service>,
+    filter: &PathFilter,
+) -> K8sInventory {
     let mut inv = K8sInventory::default();
     let helm_dirs = collect_helm_dirs(root);
 
@@ -65,6 +71,7 @@ pub fn discover(root: &Path, charts: &mut Vec<Chart>, services: &mut Vec<Service
             e.file_type().is_file()
                 && (name.ends_with(".yaml") || name.ends_with(".yml"))
                 && !crate::sources::compose::is_compose_file(&name)
+                && filter.is_allowed(&relative_str(root, e.path()))
         })
         .map(|e| e.into_path())
         .collect();

--- a/tests/monorepo-10/README.md
+++ b/tests/monorepo-10/README.md
@@ -1,0 +1,15 @@
+# monorepo-10 — env selector + path allowlist/denylist (H77)
+
+Exercises the `--env` precedence selector and the `--include`/`--exclude`
+path allowlist added for H77.
+
+- `charts/internal-api` has divergent per-environment values: the base
+  `values.yaml` keeps ingress disabled, `values-dev.yaml` turns it on,
+  `values-prod.yaml` keeps it off. With no `--env` flag, reticulum unions
+  every overlay (today's default, back-compat) so `internal-api` is
+  reported public. With `--env prod`, only the base + prod overlay are
+  analyzed, so `internal-api` is reported internal.
+- `examples/decoy-workload.yaml` is a privileged raw K8s Deployment that
+  lives outside the real deployment topology. Without a filter it is
+  discovered like any other manifest; with `--exclude examples/**` it is
+  skipped entirely and never contributes a service to the report.

--- a/tests/monorepo-10/apps/internal-api/Dockerfile
+++ b/tests/monorepo-10/apps/internal-api/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+CMD ["python", "main.py"]

--- a/tests/monorepo-10/charts/internal-api/Chart.yaml
+++ b/tests/monorepo-10/charts/internal-api/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: internal-api
+description: Internal API chart with divergent per-environment values (H77 fixture)
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/tests/monorepo-10/charts/internal-api/values-dev.yaml
+++ b/tests/monorepo-10/charts/internal-api/values-dev.yaml
@@ -1,0 +1,9 @@
+# RETICULUM TRIGGER: dev exposes this service publicly via ingress
+ingress:
+  enabled: true
+  className: "nginx"
+  hosts:
+    - host: internal-api.dev.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific

--- a/tests/monorepo-10/charts/internal-api/values-prod.yaml
+++ b/tests/monorepo-10/charts/internal-api/values-prod.yaml
@@ -1,0 +1,3 @@
+# Prod keeps this service internal — no public ingress.
+ingress:
+  enabled: false

--- a/tests/monorepo-10/charts/internal-api/values.yaml
+++ b/tests/monorepo-10/charts/internal-api/values.yaml
@@ -1,0 +1,12 @@
+image:
+  repository: mycompany/internal-api
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+# Base: no public ingress. Overridden per-environment below.
+ingress:
+  enabled: false
+
+service:
+  type: ClusterIP
+  port: 80

--- a/tests/monorepo-10/examples/decoy-workload.yaml
+++ b/tests/monorepo-10/examples/decoy-workload.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: decoy-workload
+  labels:
+    app: decoy-workload
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: decoy-workload
+  template:
+    metadata:
+      labels:
+        app: decoy-workload
+    spec:
+      containers:
+        - name: decoy
+          image: decoy-workload:1.0
+          securityContext:
+            privileged: true


### PR DESCRIPTION
## Summary

reticulum union-merges every Helm values overlay it finds (`values*.yaml`, `prod.yaml`, `staging.yaml`, `dev.yaml`, ...) and walks every YAML manifest anywhere in the repo tree, including decoy directories like `examples/` or test fixtures. Exposure therefore reflects the union of every environment ever committed, not the one topology that is actually deployed — a public prod Ingress and an internal-only dev override on the same chart average into one merged (and often misleading) risk profile.

## Changes

- **`--env <name>` selector** (`src/analyzer.rs`, `src/main.rs`): restricts Helm value analysis to the base `values.yaml`/`values.yml` plus the single overlay tagged for the given environment (`values-prod.yaml`, `values.staging.yaml`, legacy `dev.yaml`, etc.). Omitting the flag preserves today's union behavior (back-compat default).
- **`--include`/`--exclude` glob path allowlist/denylist** (new `src/pathfilter.rs`): applied uniformly to Helm chart discovery (`src/mapper.rs`), raw K8s manifest discovery (`src/sources/k8s.rs`) and compose discovery (`src/sources/compose.rs`), so a decoy path like `examples/**` can be excluded from contributing exposure signal. `--exclude` always wins over `--include`.
- **`--gitops-root <path>`** (`src/main.rs`): scans an additional external gitops/deploy repo for Helm charts and K8s manifests alongside `--path`, independent of the source-code path used for SARIF/report attribution.

## Verification

- `cargo test`: 76/76 passing (10 new inline unit tests covering env-overlay classification and glob matching in `analyzer.rs` / `pathfilter.rs`).
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo build --release`: succeeds.
- New e2e fixture `tests/monorepo-10` (divergent per-env Helm values + an `examples/` decoy raw-K8s workload) + matching CI step:
  - no `--env` flag → union of overlays, `internal-api` reported public (today's behavior, unchanged).
  - `--env prod` → `internal-api` reported internal (prod overlay disables ingress; dev overlay excluded).
  - `--exclude "examples/**"` → the decoy workload contributes no service at all.
- Re-ran the existing `monorepo-08` (raw K8s traceability) and `monorepo-06` (SARIF score snapshot) e2e checks manually — both unaffected, confirming no regression to default (no-flag) behavior.

## Test plan

- [x] `cargo test` (76 passed)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --release`
- [x] Manual e2e run of `tests/monorepo-10` (union / `--env prod` / `--exclude`) — all assertions pass
- [x] Manual re-run of existing `monorepo-08`/`monorepo-06` e2e snapshots — unaffected
- [ ] CI (this PR wires the new e2e step into `.github/workflows/ci.yml`)